### PR TITLE
Fixes to courses.py and ignored PyCharm project folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ logs/
 pip.ini
 
 
+# PyCharm
+.idea/

--- a/pycanvas/apis/__init__.py
+++ b/pycanvas/apis/__init__.py
@@ -1,0 +1,79 @@
+from account_domain_lookups import AccountDomainLookupsAPI
+from account_notifications import AccountNotificationsAPI
+from account_reports import AccountReportsAPI
+from accounts import AccountsAPI
+from admins import AdminsAPI
+from announcement_external_feeds import AnnouncementExternalFeedsAPI
+from appointment_groups import AppointmentGroupsAPI
+from assignment_groups import AssignmentGroupsAPI
+from assignments import AssignmentsAPI
+from authentications_log import AuthenticationsLogAPI
+from base import BaseCanvasAPI
+from calendar_events import CalendarEventsAPI
+from collaborations import CollaborationsAPI
+# TODO uncomment after fixed
+# from comm_messages import CommMessagesAPI
+from communication_channels import CommunicationChannelsAPI
+from conferences import ConferencesAPI
+from content_exports import ContentExportsAPI
+# TODO uncomment after fixed
+# from content_migrations import ContentMigrationsAPI
+from conversations import ConversationsAPI
+from course_audit_log import CourseAuditLogAPI
+from course_quiz_extensions import CourseQuizExtensionsAPI
+from courses import CoursesAPI
+from custom_gradebook_columns import CustomGradebookColumnsAPI
+from discussion_topics import DiscussionTopicsAPI
+from document_previews import DocumentPreviewsAPI
+from enrollment_terms import EnrollmentTermsAPI
+from enrollments import EnrollmentsAPI
+from external_tools import ExternalToolsAPI
+# TODO uncomment after fixed
+# from favorites import FavoritesAPI
+from feature_flags import FeatureFlagsAPI
+from files import FilesAPI
+from grade_change_log import GradeChangeLogAPI
+from gradebook_history import GradebookHistoryAPI
+from grading_periods import GradingPeriodsAPI
+from grading_standards import GradingStandardsAPI
+from group_categories import GroupCategoriesAPI
+from groups import GroupsAPI
+from live_assessments import LiveAssessmentsAPI
+from logins import LoginsAPI
+from modules import ModulesAPI
+# TODO uncomment after fixed
+# from notification_preferences import NotificationPreferencesAPI
+from outcome_groups import OutcomeGroupsAPI
+from outcome_results import OutcomeResultsAPI
+from outcomes import OutcomesAPI
+from pages import PagesAPI
+from poll_choices import PollChoicesAPI
+from poll_sessions import PollSessionsAPI
+from poll_submissions import PollSubmissionsAPI
+from polls import PollsAPI
+from progress import ProgressAPI
+from quiz_assignment_overrides import QuizAssignmentOverridesAPI
+from quiz_extensions import QuizExtensionsAPI
+from quiz_ip_filters import QuizIpFiltersAPI
+from quiz_question_groups import QuizQuestionGroupsAPI
+from quiz_questions import QuizQuestionsAPI
+from quiz_reports import QuizReportsAPI
+from quiz_statistics import QuizStatisticsAPI
+from quiz_submission_events import QuizSubmissionEventsAPI
+from quiz_submission_files import QuizSubmissionFilesAPI
+from quiz_submission_questions import QuizSubmissionQuestionsAPI
+from quiz_submission_user_list import QuizSubmissionUserListAPI
+from quiz_submissions import QuizSubmissionsAPI
+from quizzes import QuizzesAPI
+# TODO uncomment after fixed
+# from roles import RolesAPI
+from search import SearchAPI
+from sections import SectionsAPI
+from services import ServicesAPI
+from sis_imports import SisImportsAPI
+from submission_comments import SubmissionCommentsAPI
+# TODO uncomment after fixed
+# from submissions import SubmissionsAPI
+from tabs import TabsAPI
+from user_observees import UserObserveesAPI
+from users import UsersAPI

--- a/pycanvas/apis/announcement_external_feeds.py
+++ b/pycanvas/apis/announcement_external_feeds.py
@@ -74,7 +74,7 @@ class AnnouncementExternalFeedsAPI(BaseCanvasAPI):
             data["header_match"] = header_match
 
         # OPTIONAL - verbosity
-        """Defaults to "full""""
+        """Defaults to "full" """
         if verbosity is not None:
             self._validate_enum(verbosity, ["full", "truncate", "link_only"])
             data["verbosity"] = verbosity
@@ -106,7 +106,7 @@ class AnnouncementExternalFeedsAPI(BaseCanvasAPI):
             data["header_match"] = header_match
 
         # OPTIONAL - verbosity
-        """Defaults to "full""""
+        """Defaults to "full" """
         if verbosity is not None:
             self._validate_enum(verbosity, ["full", "truncate", "link_only"])
             data["verbosity"] = verbosity

--- a/pycanvas/apis/appointment_groups.py
+++ b/pycanvas/apis/appointment_groups.py
@@ -28,7 +28,7 @@ class AppointmentGroupsAPI(BaseCanvasAPI):
         params = {}
 
         # OPTIONAL - scope
-        """Defaults to "reservable""""
+        """Defaults to "reservable" """
         if scope is not None:
             self._validate_enum(scope, ["reservable", "manageable"])
             params["scope"] = scope
@@ -135,7 +135,7 @@ class AppointmentGroupsAPI(BaseCanvasAPI):
             data["appointment_group[new_appointments][X]"] = appointment_group_new_appointments_X
 
         # OPTIONAL - appointment_group[participant_visibility]
-        """"private":: participants cannot see who has signed up for a particular
+        """ "private":: participants cannot see who has signed up for a particular
                     time slot
         "protected":: participants can see who has signed up.  Defaults to
                       "private"."""
@@ -255,7 +255,7 @@ class AppointmentGroupsAPI(BaseCanvasAPI):
             data["appointment_group[new_appointments][X]"] = appointment_group_new_appointments_X
 
         # OPTIONAL - appointment_group[participant_visibility]
-        """"private":: participants cannot see who has signed up for a particular
+        """ "private":: participants cannot see who has signed up for a particular
                     time slot
         "protected":: participants can see who has signed up. Defaults to "private"."""
         if appointment_group_participant_visibility is not None:
@@ -305,7 +305,7 @@ class AppointmentGroupsAPI(BaseCanvasAPI):
         path["id"] = id
 
         # OPTIONAL - registration_status
-        """Limits results to the a given participation status, defaults to "all""""
+        """Limits results to the a given participation status, defaults to "all" """
         if registration_status is not None:
             self._validate_enum(registration_status, ["all", "registered", "registered"])
             params["registration_status"] = registration_status
@@ -330,7 +330,7 @@ class AppointmentGroupsAPI(BaseCanvasAPI):
         path["id"] = id
 
         # OPTIONAL - registration_status
-        """Limits results to the a given participation status, defaults to "all""""
+        """Limits results to the a given participation status, defaults to "all" """
         if registration_status is not None:
             self._validate_enum(registration_status, ["all", "registered", "registered"])
             params["registration_status"] = registration_status

--- a/pycanvas/apis/calendar_events.py
+++ b/pycanvas/apis/calendar_events.py
@@ -27,7 +27,7 @@ class CalendarEventsAPI(BaseCanvasAPI):
         params = {}
 
         # OPTIONAL - type
-        """Defaults to "event""""
+        """Defaults to "event" """
         if type is not None:
             self._validate_enum(type, ["event", "assignment"])
             params["type"] = type
@@ -68,7 +68,7 @@ class CalendarEventsAPI(BaseCanvasAPI):
             params["context_codes"] = context_codes
 
         # OPTIONAL - excludes
-        """Array of attributes to exclude. Possible values are "description", "child_events" and "assignment""""
+        """Array of attributes to exclude. Possible values are "description", "child_events" and "assignment" """
         if excludes is not None:
             params["excludes"] = excludes
 
@@ -92,7 +92,7 @@ class CalendarEventsAPI(BaseCanvasAPI):
         path["user_id"] = user_id
 
         # OPTIONAL - type
-        """Defaults to "event""""
+        """Defaults to "event" """
         if type is not None:
             self._validate_enum(type, ["event", "assignment"])
             params["type"] = type
@@ -133,7 +133,7 @@ class CalendarEventsAPI(BaseCanvasAPI):
             params["context_codes"] = context_codes
 
         # OPTIONAL - excludes
-        """Array of attributes to exclude. Possible values are "description", "child_events" and "assignment""""
+        """Array of attributes to exclude. Possible values are "description", "child_events" and "assignment" """
         if excludes is not None:
             params["excludes"] = excludes
 

--- a/pycanvas/apis/courses.py
+++ b/pycanvas/apis/courses.py
@@ -126,7 +126,7 @@ class CoursesAPI(BaseCanvasAPI):
           {api:TabsController#index List available tabs API} for more information."""
         if include is not None:
             self._validate_enum(include, ["needs_grading_count", "syllabus_body", "public_description", "total_scores", "current_grading_period_scores", "term", "course_progress", "sections", "storage_quota_used_mb", "total_students", "passback_status", "favorites", "teachers", "observed_users"])
-            params["include"] = include
+            params["include[]"] = include
 
         # OPTIONAL - state
         """If set, only return courses that are in the given state(s).
@@ -219,7 +219,7 @@ class CoursesAPI(BaseCanvasAPI):
           {api:TabsController#index List available tabs API} for more information."""
         if include is not None:
             self._validate_enum(include, ["needs_grading_count", "syllabus_body", "public_description", "total_scores", "current_grading_period_scores", "term", "course_progress", "sections", "storage_quota_used_mb", "total_students", "passback_status", "favorites", "teachers", "observed_users"])
-            params["include"] = include
+            params["include[]"] = include
 
         # OPTIONAL - state
         """If set, only return courses that are in the given state(s).
@@ -517,7 +517,7 @@ class CoursesAPI(BaseCanvasAPI):
         such as analytics information"""
         if include is not None:
             self._validate_enum(include, ["email", "enrollments", "locked", "avatar_url", "test_student", "bio", "custom_links"])
-            params["include"] = include
+            params["include[]"] = include
 
         # OPTIONAL - user_id
         """If this parameter is given and it corresponds to a user in the course,
@@ -605,7 +605,7 @@ class CoursesAPI(BaseCanvasAPI):
         such as analytics information"""
         if include is not None:
             self._validate_enum(include, ["email", "enrollments", "locked", "avatar_url", "test_student", "bio", "custom_links"])
-            params["include"] = include
+            params["include[]"] = include
 
         # OPTIONAL - user_id
         """If this parameter is given and it corresponds to a user in the course,
@@ -890,7 +890,7 @@ class CoursesAPI(BaseCanvasAPI):
         - "observed_users": include observed users in the enrollments"""
         if include is not None:
             self._validate_enum(include, ["needs_grading_count", "syllabus_body", "public_description", "total_scores", "current_grading_period_scores", "term", "course_progress", "sections", "storage_quota_used_mb", "total_students", "passback_status", "favorites", "teachers", "observed_users", "all_courses", "permissions", "observed_users"])
-            params["include"] = include
+            params["include[]"] = include
 
         self.logger.debug("GET /api/v1/courses/{id} with query params: {params} and form data: {data}".format(params=params, data=data, **path))
         return self.generic_request("GET", "/api/v1/courses/{id}".format(**path), data=data, params=params, single_item=True)
@@ -922,7 +922,7 @@ class CoursesAPI(BaseCanvasAPI):
         - "observed_users": include observed users in the enrollments"""
         if include is not None:
             self._validate_enum(include, ["needs_grading_count", "syllabus_body", "public_description", "total_scores", "current_grading_period_scores", "term", "course_progress", "sections", "storage_quota_used_mb", "total_students", "passback_status", "favorites", "teachers", "observed_users", "all_courses", "permissions", "observed_users"])
-            params["include"] = include
+            params["include[]"] = include
 
         self.logger.debug("GET /api/v1/accounts/{account_id}/courses/{id} with query params: {params} and form data: {data}".format(params=params, data=data, **path))
         return self.generic_request("GET", "/api/v1/accounts/{account_id}/courses/{id}".format(**path), data=data, params=params, single_item=True)


### PR DESCRIPTION
I discovered that some of the include parameters in the CoursesAPI didn't match Instructure's goofy use of brackets in their parameter names. I made the change which fixed the issues I was experiencing when trying to include additional information in the calls.